### PR TITLE
fixed the footer covering other components error

### DIFF
--- a/src/Components/Footer/StyledFooter.js
+++ b/src/Components/Footer/StyledFooter.js
@@ -3,7 +3,5 @@ import { styled } from '@mui/material/styles';
 export const StyledFooter = styled('footer')(({ theme }) => ({
     padding: theme.spacing(1),
     backgroundColor: theme.palette.primary.main,
-    position: 'fixed',
-    bottom: '0',
     width: '100%'
 }));


### PR DESCRIPTION
The footer was covering other components because of the position fixed in CSS, I took it off.
![image](https://github.com/JSD-0423/frontend-final-3/assets/69960121/886b384e-021e-48f1-a030-9377409fe846)
